### PR TITLE
[BUG]: prompt-submit fail to grab session fails silently (web/app)

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -425,6 +425,7 @@ export function UserMessageDisplay(props: { message: UserMessage; parts: PartTyp
               <IconButton
                 icon={copied() ? "check" : "copy"}
                 variant="secondary"
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={(event) => {
                   event.stopPropagation()
                   handleCopy()
@@ -701,6 +702,7 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
               <IconButton
                 icon={copied() ? "check" : "copy"}
                 variant="secondary"
+                onMouseDown={(e) => e.preventDefault()}
                 onClick={handleCopy}
                 aria-label={copied() ? i18n.t("ui.message.copied") : i18n.t("ui.message.copy")}
               />

--- a/packages/ui/src/components/session-turn.tsx
+++ b/packages/ui/src/components/session-turn.tsx
@@ -626,6 +626,7 @@ export function SessionTurn(
                                   <IconButton
                                     icon={copied() ? "check" : "copy"}
                                     variant="secondary"
+                                    onMouseDown={(e) => e.preventDefault()}
                                     onClick={(event) => {
                                       event.stopPropagation()
                                       handleCopy()


### PR DESCRIPTION
Description
When you submit a message and the session fails to retrieve, the UX fails silently (no toast, console error, or failed request).

Multiple users have reported that when they send a message nothing happens, I reproed it myself. (it's hard to tell if we're all facing the same issue or if there are different variants because it fails silently)

Proposed fix i'm working on: toast a descriptive message when this happens