### PR TITLE
feat(file): navigate to files from @file reference

### DIFF
--- a/packages/app/src/components/dialog-settings.tsx
+++ b/packages/app/src/components/dialog-settings.tsx
@@ -3,6 +3,8 @@ import { Dialog } from "@opencode-ai/ui/dialog"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { Icon } from "@opencode-ai/ui/icon"
 import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
+import pkg from "../package.json"
 import { SettingsGeneral } from "./settings-general"
 import { SettingsKeybinds } from "./settings-keybinds"
 import { SettingsPermissions } from "./settings-permissions"
@@ -14,6 +16,7 @@ import { SettingsMcp } from "./settings-mcp"
 
 export const DialogSettings: Component = () => {
   const language = useLanguage()
+  const platform = usePlatform()
 
   return (
     <Dialog size="x-large">
@@ -23,22 +26,35 @@ export const DialogSettings: Component = () => {
             style={{
               display: "flex",
               "flex-direction": "column",
-              gap: "12px",
+              "justify-content": "space-between",
+              height: "100%",
               width: "100%",
-              "padding-top": "12px",
-              "padding-bottom": "12px",
             }}
           >
-            <Tabs.SectionTitle>{language.t("settings.section.desktop")}</Tabs.SectionTitle>
-            <div style={{ display: "flex", "flex-direction": "column", gap: "6px", width: "100%" }}>
-              <Tabs.Trigger value="general">
-                <Icon name="sliders" />
-                {language.t("settings.tab.general")}
-              </Tabs.Trigger>
-              <Tabs.Trigger value="shortcuts">
-                <Icon name="keyboard" />
-                {language.t("settings.tab.shortcuts")}
-              </Tabs.Trigger>
+            <div
+              style={{
+                display: "flex",
+                "flex-direction": "column",
+                gap: "12px",
+                width: "100%",
+                "padding-top": "12px",
+              }}
+            >
+              <Tabs.SectionTitle>{language.t("settings.section.desktop")}</Tabs.SectionTitle>
+              <div style={{ display: "flex", "flex-direction": "column", gap: "6px", width: "100%" }}>
+                <Tabs.Trigger value="general">
+                  <Icon name="sliders" />
+                  {language.t("settings.tab.general")}
+                </Tabs.Trigger>
+                <Tabs.Trigger value="shortcuts">
+                  <Icon name="keyboard" />
+                  {language.t("settings.tab.shortcuts")}
+                </Tabs.Trigger>
+              </div>
+            </div>
+            <div class="flex flex-col gap-1 pl-1 py-1 text-12-medium text-text-weak">
+              <span>OpenCode Desktop</span>
+              <span class="text-11-regular">v{platform.version}</span>
             </div>
           </div>
           {/* <Tabs.SectionTitle>Server</Tabs.SectionTitle> */}

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -1964,7 +1964,9 @@ export default function Layout(props: ParentProps) {
 
           <Collapsible.Content>
             <nav class="flex flex-col gap-1 px-2">
-              <NewSessionItem slug={slug()} mobile={props.mobile} />
+              <Show when={workspaceSetting()}>
+                <NewSessionItem slug={slug()} mobile={props.mobile} />
+              </Show>
               <Show when={loading()}>
                 <SessionSkeleton />
               </Show>
@@ -2171,7 +2173,9 @@ export default function Layout(props: ParentProps) {
         style={{ "overflow-anchor": "none" }}
       >
         <nav class="flex flex-col gap-1 px-2">
-          <NewSessionItem slug={slug()} mobile={props.mobile} />
+          <Show when={workspaceSetting()}>
+            <NewSessionItem slug={slug()} mobile={props.mobile} />
+          </Show>
           <Show when={loading()}>
             <SessionSkeleton />
           </Show>


### PR DESCRIPTION
What does this PR do?
ADd navigation when clicking a https://github.com/file reference from prompt-input and context items (attachment files with CTRL + L keybind)


If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

How did you verify your code works?
Verified UI Interactivity

when a https://github.com/file is attached, there is not hover interactions (before)