### PR TITLE
fix(tui): cannot paste clipboard text on windows

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
+++ b/packages/opencode/src/cli/cmd/tui/util/clipboard.ts
@@ -74,18 +74,36 @@ export async function read(): Promise<Content | undefined> {
     }
   }
 
-  // Windows/WSL: probe clipboard for images via PowerShell.
-  // Bracketed paste can't carry image data so we read it directly.
+  // Windows/WSL: read image and text via PowerShell. clipboardy's bundled .exe
+  // fails silently under Bun on Windows, so we bypass it for text too.
   if (os === "win32" || release().includes("WSL")) {
     const script =
-      "Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img) { $ms = New-Object System.IO.MemoryStream; $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); [System.Convert]::ToBase64String($ms.ToArray()) }"
-    const base64 = await Process.text(["powershell.exe", "-NonInteractive", "-NoProfile", "-command", script], {
+      "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; " +
+      "Add-Type -AssemblyName System.Windows.Forms; " +
+      "$img = [System.Windows.Forms.Clipboard]::GetImage(); " +
+      "if ($img) { " +
+      "  $ms = New-Object System.IO.MemoryStream; " +
+      "  $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png); " +
+      "  Write-Output ('IMG:' + [System.Convert]::ToBase64String($ms.ToArray())) " +
+      "} else { " +
+      "  $t = Get-Clipboard -Raw; " +
+      "  if ($t) { Write-Output ('TXT:' + [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($t))) } " +
+      "}"
+    const result = await Process.text(["powershell.exe", "-NonInteractive", "-NoProfile", "-Command", script], {
       nothrow: true,
     })
-    if (base64.text) {
-      const imageBuffer = Buffer.from(base64.text.trim(), "base64")
+    const raw = result.text.trim()
+    if (raw.startsWith("IMG:")) {
+      const imageBuffer = Buffer.from(raw.slice(4), "base64")
       if (imageBuffer.length > 0) {
         return { data: imageBuffer.toString("base64"), mime: "image/png" }
+      }
+    }
+    if (raw.startsWith("TXT:")) {
+      const decoded = Buffer.from(raw.slice(4), "base64").toString("utf8")
+      const normalized = decoded.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n$/, "")
+      if (normalized.length > 0) {
+        return { data: normalized, mime: "text/plain" }
       }
     }
   }


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, `Ctrl+V` text paste in the TUI prompt does nothing. Image paste still works.

`Clipboard.read()` on Windows probes images via PowerShell, then falls through to `clipboardy.read()` for text. `clipboardy@4.0.0` runs a bundled `clipboard_x86_64.exe` through `execa`, which fails silently under Bun on Windows. The surrounding `.catch(() => {})` swallows the error, so the paste command returns `undefined` and inserts nothing.

Fix: read text in the same PowerShell call as images via `Get-Clipboard -Raw`. Both payloads are base64-encoded and tagged (`IMG:` / `TXT:`) so binary image bytes and Unicode text share one stdout stream without corruption. `clipboardy` is left as the cross-platform fallback.

### How did you verify your code works?
Manual test on Windows 10 + Windows Terminal:
- plain text paste → inserted (previously: nothing)
- multi-line text with CRLF → newlines normalized to LF
- non-ASCII text → inserted intact
- image paste → `[Image N]` still works
- empty clipboard → no-op

### Screenshots / recordings

_N/A — terminal text input._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Files changed
Files | Changes
--- | ---
packages/opencode/src/cli/cmd/tui/util/clipboard.ts | Read text via `Get-Clipboard -Raw` alongside image probe; tag payloads `IMG:`/`TXT:`
